### PR TITLE
changing default labels for ZIO deps to RC20; removing the `*_RC19*` imports; 

### DIFF
--- a/third_party/dev_zio.bzl
+++ b/third_party/dev_zio.bzl
@@ -4,21 +4,25 @@ def dependencies():
 
     import_external(
         name = "dev_zio_zio_2_12",
-        artifact = "dev.zio:zio_2.12:1.0.0-RC17",
-        artifact_sha256 = "35ade72b393ff4dc6f43f00a7c8a3e7e6c9fe4b09135c587380d361ce87ffdfb",
-        srcjar_sha256 = "0fb84fd9ed5dbf8b1faf903b349842b11cad86ea61e93b04e7e9e75f17bac537",
+        artifact = "dev.zio:zio_2.12:1.0.0-RC20",
+        artifact_sha256 = "be4de9756340ff761d3b51e67f26ee1c30a8f6b934df68f69fc7f3182819e87f",
+        srcjar_sha256 = "9c094269da35fc0174ddf52460c647fe1cefddd88f8b71ee67ff61c80bc1d1b5",
         deps = [
+            "@dev_zio_izumi_reflect_2_12",
             "@dev_zio_zio_stacktracer_2_12",
             "@org_scala_lang_scala_library"
         ],
+        exports = [
+            "@dev_zio_izumi_reflect_2_12",
+            "@dev_zio_izumi_reflect_thirdparty_boopickle_shaded_2_12",
+        ]
     )
-
 
     import_external(
         name = "dev_zio_zio_stacktracer_2_12",
-        artifact = "dev.zio:zio-stacktracer_2.12:1.0.0-RC17",
-        artifact_sha256 = "dd43181922c418d5ab896c7f1f5f1e95ee2b5c23087a88f36e1e8979418fc36b",
-        srcjar_sha256 = "87bb8a7c61f8d6359af08eb0635ece6f27805ebbe49ee747976d2b92c7f1e153",
+        artifact = "dev.zio:zio-stacktracer_2.12:1.0.0-RC20",
+        artifact_sha256 = "4cda54047ec56b9945ef1e5dbc0cc7360403423d181567540a52bfbb590107f2",
+        srcjar_sha256 = "c4ca838c7e5b3328cc5524e11308114daa5a1063eec11cbe813f0de15b4322ef",
         deps = [
             "@org_scala_lang_scala_library"
         ],
@@ -27,11 +31,56 @@ def dependencies():
 
     import_external(
         name = "dev_zio_zio_streams_2_12",
-        artifact = "dev.zio:zio-streams_2.12:1.0.0-RC17",
-        artifact_sha256 = "640cfa72edc83708b51d454046f4e87bd2a0357141ccf68bf82aaccc736d2a65",
-        srcjar_sha256 = "e77ebd39bbeca257f0a774e5d10015cffc0b0b2728f574640b2e6c53da269120",
+        artifact = "dev.zio:zio-streams_2.12:1.0.0-RC20",
+        artifact_sha256 = "d74002c750e696ddb0f935b45f8a248ca4e5349c241ef121db01d75f18fcabbe",
+        srcjar_sha256 = "ab68dce1e50beebe1407602794bf228dfa29967566062878e47ddaca9b8d773f",
         deps = [
             "@dev_zio_zio_2_12",
+            "@org_scala_lang_scala_library"
+        ],
+    )
+
+    import_external(
+        name = "dev_zio_zio_macros_core_2_12",
+        artifact = "dev.zio:zio-macros-core_2.12:0.6.2",
+        artifact_sha256 = "cdf4bef65f01977f30c993eb0d1e0a5951a0b04b899be70bcd941d9563aea15e",
+        srcjar_sha256 = "b537116c00fd825a067bdbdaa6bcb81d0a23c54508b6b96ac23a24ebc8872a22",
+        deps = [
+            "@dev_zio_zio_2_12",
+            "@org_scala_lang_scala_library"
+        ],
+    )
+
+    import_external(
+        name = "dev_zio_izumi_reflect_2_12",
+        artifact = "dev.zio:izumi-reflect_2.12:1.0.0-M2",
+        artifact_sha256 = "67e1f98924ba6547d18ac696f4cd8a0fb70307be9632f2bed0baf14535814bfb",
+        srcjar_sha256 = "9c421c38c4d534098942263f35c896b6bfe6419a8ce9e4a02e2440e61298ec7d",
+        deps = [
+            "@dev_zio_izumi_reflect_thirdparty_boopickle_shaded_2_12",
+            "@org_scala_lang_scala_library"
+        ],
+    )
+
+
+    import_external(
+        name = "dev_zio_izumi_reflect_thirdparty_boopickle_shaded_2_12",
+        artifact = "dev.zio:izumi-reflect-thirdparty-boopickle-shaded_2.12:1.0.0-M2",
+        artifact_sha256 = "71dd2cca07ff8ae9f892da3bbf5c21e598c3b5ad73b2603b88342af884a4a147",
+        srcjar_sha256 = "136689b6254e67499ba1fadb41dc3d5b3b1236d04f96b9111550105baffd2da8",
+        deps = [
+            "@org_scala_lang_scala_library"
+        ],
+    )
+
+    import_external(
+        name = "dev_zio_zio_test_junit_2_12",
+        artifact = "dev.zio:zio-test-junit_2.12:1.0.0-RC20",
+        artifact_sha256 = "6e9d050362ab80865d1675b8e9e65b46cca94234f71f39f5e3c3c1e346f5b32b",
+        srcjar_sha256 = "870e60253f2da1a76a1ae035a5808351e43c5cc34920f9c0cd91545bcb7a58a0",
+        deps = [
+            "@dev_zio_zio_test_2_12",
+            "@junit_junit",
             "@org_scala_lang_scala_library"
         ],
     )
@@ -39,9 +88,9 @@ def dependencies():
 
     import_external(
         name = "dev_zio_zio_test_2_12",
-        artifact = "dev.zio:zio-test_2.12:1.0.0-RC17",
-        artifact_sha256 = "d5415b493da334da445ee1bc829550cb5c32f76e9035c43ce3ed781f43249c7e",
-        srcjar_sha256 = "c16dad2b0064cd7afed2d485c422ab0666a9ad76fea2519050d9e4fc636f3c9b",
+        artifact = "dev.zio:zio-test_2.12:1.0.0-RC20",
+        artifact_sha256 = "19c95085370ab22fc832a30d13eec3038ddc79e8f1f338568e4c63744bba156c",
+        srcjar_sha256 = "cad1893fb66938a614e3b680dd9eaca593df8bee6d050427e8f4934df10b6310",
         deps = [
             "@dev_zio_zio_2_12",
             "@dev_zio_zio_streams_2_12",


### PR DESCRIPTION

#automerge